### PR TITLE
feat: CF domain mask

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,3 +1,7 @@
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "cloudfront origin access identity"
+}
+
 resource "aws_cloudfront_distribution" "share_files_securely" {
   enabled     = true
   aliases     = ["share-files.cdssandbox.xyz"]
@@ -12,6 +16,15 @@ resource "aws_cloudfront_distribution" "share_files_securely" {
       https_port             = 443
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  origin {
+    domain_name = module.share_files_securely_bucket.s3_bucket_regional_domain_name
+    origin_id   = "${module.share_files_securely_bucket.s3_bucket_id}-bucket"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
     }
   }
 
@@ -51,6 +64,28 @@ resource "aws_cloudfront_distribution" "share_files_securely" {
     default_ttl = 0
     max_ttl     = 0
     compress    = true
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/*@cds-snc.ca/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${module.share_files_securely_bucket.s3_bucket_id}-bucket"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
   }
 
   restrictions {


### PR DESCRIPTION
This PR adds a route to CloudFront that will allow you to access the files through the CloudFront URL vs the raw bucket URL