### PR TITLE
fix: caps the share limit at 167 hours (7*24 - 1)

### DIFF
--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -28,7 +28,7 @@
             <option value="6">6 {{t("hours")}}</option>
             <option value="24">1 {{t("day")}}</option>
             <option value="120">5 {{t("days")}}</option>
-            <option value="336">14 {{t("days")}}</option>
+            <option value="167">7 {{t("days")}}</option>
         </select>
     </div>
     <div class="buttons">


### PR DESCRIPTION
> X-Amz-Expires must be less than a week (in seconds); that is, the given X-Amz-Expires must be less than 604800 seconds

is something that came up in testing, so we reduced the max option to 6 days and 23 hours (round up to seven days)