### PR TITLE
fix: s3_scan_object multi bucket support

### DIFF
--- a/terraform/file_scanning.tf
+++ b/terraform/file_scanning.tf
@@ -1,13 +1,10 @@
 module "s3_scan_objects" {
-  source                = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.1.5"
-  s3_upload_bucket_name = module.share_files_securely_bucket.s3_bucket_id
-  billing_tag_value     = var.billing_code
-}
+  source = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v7.0.0"
 
-module "s3_scan_objects_dev" {
-  source                        = "github.com/cds-snc/terraform-modules//S3_scan_object?ref=v6.1.5"
-  scan_queue_suffix             = "DEV"
-  s3_upload_bucket_name         = module.share_files_securely_bucket_dev.s3_bucket_id
-  scan_files_assume_role_create = false
-  billing_tag_value             = var.billing_code
+  s3_upload_bucket_names = [
+    module.share_files_securely_bucket.s3_bucket_id,
+    module.share_files_securely_bucket_dev.s3_bucket_id
+  ]
+
+  billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the `s3_scan_object` module to support multiple buckets using the same scanning queue.

# Related
- https://github.com/cds-snc/terraform-modules/pull/278